### PR TITLE
FEATURE: GitHub SSO

### DIFF
--- a/src/login.rs
+++ b/src/login.rs
@@ -109,7 +109,7 @@ fn login_menu(
             )));
         }
         if github_button.clicked() {
-            let client_id = env::var("GITHUB_CLIENT_ID").is_ok();
+            let client_id = env::var("GITHUB_CLIENT_ID").unwrap();
             ui_state.login_status = LoginStatus::LoggingIn;
             event_writer.send(NetworkCommand::GithubAuth(GitHubAuthRequest::new(
                 client_id,

--- a/src/login.rs
+++ b/src/login.rs
@@ -1,7 +1,8 @@
 use bevy::prelude::*;
 use bevy_egui::{egui, EguiContext};
+use std::env;
 
-use crate::network::{LoginForm, LoginResult, NetworkCommand};
+use crate::network::{GitHubAuthRequest, LoginForm, LoginResult, NetworkCommand};
 use crate::{GameState, MySystemLabel};
 
 pub struct LoginMenuPlugin;
@@ -96,11 +97,22 @@ fn login_menu(
             ui_state.login_status.enable_login_button(),
             egui::Button::new("Login"),
         );
+        let github_button = ui.add_enabled(
+            ui_state.login_status.enable_login_button(),
+            egui::Button::new("Github"),
+        );
         if button.clicked() {
             ui_state.login_status = LoginStatus::LoggingIn;
             event_writer.send(NetworkCommand::Login(LoginForm::new(
                 ui_state.username.as_str(),
                 ui_state.password.as_str(),
+            )));
+        }
+        if github_button.clicked() {
+            let client_id = env::var("GITHUB_CLIENT_ID").is_ok();
+            ui_state.login_status = LoginStatus::LoggingIn;
+            event_writer.send(NetworkCommand::GithubAuth(GitHubAuthRequest::new(
+                client_id,
             )));
         }
         ui.add_visible(

--- a/src/login.rs
+++ b/src/login.rs
@@ -1,6 +1,5 @@
 use bevy::prelude::*;
 use bevy_egui::{egui, EguiContext};
-use std::collections::HashMap;
 use std::{env, fmt};
 
 use crate::network::{GitHubAuthRequest, LoginForm, LoginResult, NetworkCommand, SwapTokenRequest};
@@ -37,9 +36,9 @@ impl GitHubAuthData {
 
 impl fmt::Debug for GitHubAuthData {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let mut output = HashMap::new();
-        output.insert("user_code", &self.user_code);
-        write!(f, "GitHubAuthData {:?}", output)
+        f.debug_struct("GitHubAuthData")
+            .field("user_code", &self.user_code)
+            .finish()
     }
 }
 

--- a/src/network/github.rs
+++ b/src/network/github.rs
@@ -1,5 +1,5 @@
-use std::fmt;
 use serde::{Deserialize, Serialize};
+use std::fmt;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct GitHubAuthRequest {
@@ -43,10 +43,11 @@ impl GitHubTempTokenResponse {
 
 impl fmt::Debug for GitHubTempTokenResponse {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-
-        write!(f, "GithHubTempTokenResponse: device_code: ****, expires_in: {}, interval: {}, user_code: ****, verification_uri: {}",
-        self.expires_in, self.interval, self.verification_uri)
-
+        write!(
+            f,
+            "GithHubTempTokenResponse: device_code: ****, expires_in: {}, interval: {}, \
+            user_code: ****, verification_uri: {}",
+            self.expires_in, self.interval, self.verification_uri
+        )
     }
-
 }

--- a/src/network/github.rs
+++ b/src/network/github.rs
@@ -1,5 +1,10 @@
+use reqwest::Error;
 use serde::{Deserialize, Serialize};
 
+#[derive(Debug)]
+pub enum LoginError {
+    Request(Error),
+}
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct GitHubAuthRequest {
     pub client_id: String,

--- a/src/network/github.rs
+++ b/src/network/github.rs
@@ -5,6 +5,14 @@ pub struct GitHubAuthRequest {
     pub client_id: String,
 }
 
+impl GitHubAuthRequest {
+    pub fn new(client_id: impl Into<String>) -> Self {
+        Self {
+            client_id: client_id.into(),
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct GitHubTempTokenResponse {
     pub device_code: String,

--- a/src/network/github.rs
+++ b/src/network/github.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct GitHubAuthRequest {
-    pub code: String,
+    pub client_id: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]

--- a/src/network/github.rs
+++ b/src/network/github.rs
@@ -1,3 +1,4 @@
+use std::fmt;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]

--- a/src/network/github.rs
+++ b/src/network/github.rs
@@ -1,4 +1,3 @@
-use reqwest::Error;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]

--- a/src/network/github.rs
+++ b/src/network/github.rs
@@ -3,7 +3,7 @@ use std::fmt;
 
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct GitHubAuthRequest {
     pub client_id: String,
 }
@@ -13,6 +13,14 @@ impl GitHubAuthRequest {
         Self {
             client_id: client_id.into(),
         }
+    }
+}
+
+impl fmt::Debug for GitHubAuthRequest {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let mut output = HashMap::new();
+        output.insert("client_id", "****");
+        write!(f, "GithHubTempTokenResponse {:?}", output)
     }
 }
 

--- a/src/network/github.rs
+++ b/src/network/github.rs
@@ -1,7 +1,11 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct GitHubAuthRequest {
     pub code: String,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct GitHubTempTokenResponse {
     pub device_code: String,
     pub expires_in: u8,

--- a/src/network/github.rs
+++ b/src/network/github.rs
@@ -13,7 +13,7 @@ impl GitHubAuthRequest {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct GitHubTempTokenResponse {
     pub device_code: String,
     pub expires_in: i32,
@@ -38,4 +38,14 @@ impl GitHubTempTokenResponse {
             verification_uri: verification_uri.into(),
         }
     }
+}
+
+impl fmt::Debug for GitHubTempTokenResponse {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+
+        write!(f, "GithHubTempTokenResponse: device_code: ****, expires_in: {}, interval: {}, user_code: ****, verification_uri: {}",
+        self.expires_in, self.interval, self.verification_uri);
+
+    }
+
 }

--- a/src/network/github.rs
+++ b/src/network/github.rs
@@ -16,8 +16,26 @@ impl GitHubAuthRequest {
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct GitHubTempTokenResponse {
     pub device_code: String,
-    pub expires_in: u8,
+    pub expires_in: i32,
     pub interval: u8,
     pub user_code: String,
     pub verification_uri: String,
+}
+
+impl GitHubTempTokenResponse {
+    pub fn new(
+        device_code: impl Into<String>,
+        expires_in: impl Into<i32>,
+        interval: impl Into<u8>,
+        user_code: impl Into<String>,
+        verification_uri: impl Into<String>,
+    ) -> Self {
+        Self {
+            device_code: device_code.into(),
+            expires_in: expires_in.into(),
+            interval: interval.into(),
+            user_code: user_code.into(),
+            verification_uri: verification_uri.into(),
+        }
+    }
 }

--- a/src/network/github.rs
+++ b/src/network/github.rs
@@ -1,0 +1,11 @@
+pub struct GitHubAuthRequest {
+    pub code: String,
+}
+
+pub struct GitHubTempTokenResponse {
+    pub device_code: String,
+    pub expires_in: u8,
+    pub interval: u8,
+    pub user_code: String,
+    pub verification_uri: String,
+}

--- a/src/network/github.rs
+++ b/src/network/github.rs
@@ -45,7 +45,7 @@ impl fmt::Debug for GitHubTempTokenResponse {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
 
         write!(f, "GithHubTempTokenResponse: device_code: ****, expires_in: {}, interval: {}, user_code: ****, verification_uri: {}",
-        self.expires_in, self.interval, self.verification_uri);
+        self.expires_in, self.interval, self.verification_uri)
 
     }
 

--- a/src/network/github.rs
+++ b/src/network/github.rs
@@ -1,5 +1,7 @@
-use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use std::fmt;
+
+use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct GitHubAuthRequest {
@@ -43,11 +45,13 @@ impl GitHubTempTokenResponse {
 
 impl fmt::Debug for GitHubTempTokenResponse {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(
-            f,
-            "GithHubTempTokenResponse: device_code: ****, expires_in: {}, interval: {}, \
-            user_code: ****, verification_uri: {}",
-            self.expires_in, self.interval, self.verification_uri
-        )
+        let mut output = HashMap::new();
+        let interval = self.interval.to_string();
+        let veri_uri = self.verification_uri.to_string();
+        output.insert("device_code", "****");
+        output.insert("interval", &interval);
+        output.insert("user_code", "****");
+        output.insert("verification_uri", &veri_uri);
+        write!(f, "GithHubTempTokenResponse {:?}", output)
     }
 }

--- a/src/network/github.rs
+++ b/src/network/github.rs
@@ -1,10 +1,6 @@
 use reqwest::Error;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug)]
-pub enum LoginError {
-    Request(Error),
-}
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct GitHubAuthRequest {
     pub client_id: String,

--- a/src/network/github.rs
+++ b/src/network/github.rs
@@ -1,4 +1,3 @@
-use std::collections::HashMap;
 use std::fmt;
 
 use serde::{Deserialize, Serialize};
@@ -18,9 +17,9 @@ impl GitHubAuthRequest {
 
 impl fmt::Debug for GitHubAuthRequest {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let mut output = HashMap::new();
-        output.insert("client_id", "****");
-        write!(f, "GitHubAuthRequest {:?}", output)
+        f.debug_struct("GitHubAuthRequest")
+            .field("client_id", &"****")
+            .finish()
     }
 }
 
@@ -53,13 +52,13 @@ impl GitHubTempTokenResponse {
 
 impl fmt::Debug for GitHubTempTokenResponse {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let mut output = HashMap::new();
         let interval = self.interval.to_string();
         let veri_uri = self.verification_uri.to_string();
-        output.insert("device_code", "****");
-        output.insert("interval", &interval);
-        output.insert("user_code", "****");
-        output.insert("verification_uri", &veri_uri);
-        write!(f, "GithHubTempTokenResponse {:?}", output)
+        f.debug_struct("GitHubTempTokenResponse")
+            .field("device_code", &"****")
+            .field("interval", &interval)
+            .field("user_code", &"****")
+            .field("verification_uri", &veri_uri)
+            .finish()
     }
 }

--- a/src/network/github.rs
+++ b/src/network/github.rs
@@ -20,7 +20,7 @@ impl fmt::Debug for GitHubAuthRequest {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let mut output = HashMap::new();
         output.insert("client_id", "****");
-        write!(f, "GithHubTempTokenResponse {:?}", output)
+        write!(f, "GitHubAuthRequest {:?}", output)
     }
 }
 

--- a/src/network/github_service.rs
+++ b/src/network/github_service.rs
@@ -1,10 +1,12 @@
-use crate::network::{Body, GitHubAuthRequest, GitHubTempTokenResult, Query, ServerConnection};
-use reqwest::{IntoUrl, Method};
+use crate::network::{Body, GitHubAuthRequest, GitHubTempTokenResponse, Query, ServerConnection};
+use reqwest::{Error, IntoUrl, Method};
 
 /// Service to provide call to github routes.
 pub struct GitHubService {
     server_connection: ServerConnection,
 }
+
+pub type GitHubTempTokenResult = Result<GitHubTempTokenResponse, Error>;
 
 impl GitHubService {
     /// Constructor

--- a/src/network/github_service.rs
+++ b/src/network/github_service.rs
@@ -1,6 +1,6 @@
-use crate::network::{Body, GitHubAuthRequest, GitHubTempTokenResponse, Query, ServerConnection};
-use reqwest::header::HeaderMap;
 use reqwest::{Error, IntoUrl, Method};
+
+use crate::network::{Body, GitHubAuthRequest, GitHubTempTokenResponse, Query, ServerConnection};
 
 /// Service to provide call to github routes.
 pub struct GitHubService {
@@ -20,15 +20,13 @@ impl GitHubService {
     }
 
     pub async fn request_github_auth(&self, body: &GitHubAuthRequest) -> GitHubTempTokenResult {
-        let mut headers = HeaderMap::new();
-        headers.insert("Accept", "application/json".parse().unwrap());
         self.server_connection
             .request_with_json_result(
                 Method::POST,
                 "login/device/code",
                 Query::<()>::None,
                 Body::Json(body),
-                Some(headers),
+                None,
             )
             .await
     }

--- a/src/network/github_service.rs
+++ b/src/network/github_service.rs
@@ -1,0 +1,29 @@
+use crate::network::{Body, GitHubAuthRequest, GitHubTempTokenResult, Query, ServerConnection};
+use reqwest::{IntoUrl, Method};
+
+/// Service to provide call to github routes.
+pub struct GitHubService {
+    server_connection: ServerConnection,
+}
+
+impl GitHubService {
+    /// Constructor
+    /// # Arguments
+    /// * 'base_url' the url of the server
+    pub fn new(base_url: impl IntoUrl) -> Self {
+        Self {
+            server_connection: ServerConnection::new(base_url),
+        }
+    }
+
+    pub async fn request_github_auth(&self, body: &GitHubAuthRequest) -> GitHubTempTokenResult {
+        self.server_connection
+            .request_with_json_result(
+                Method::POST,
+                "login/device/code",
+                Query::<()>::None,
+                Body::Json(body),
+            )
+            .await
+    }
+}

--- a/src/network/github_service.rs
+++ b/src/network/github_service.rs
@@ -1,4 +1,5 @@
 use crate::network::{Body, GitHubAuthRequest, GitHubTempTokenResponse, Query, ServerConnection};
+use reqwest::header::HeaderMap;
 use reqwest::{Error, IntoUrl, Method};
 
 /// Service to provide call to github routes.
@@ -19,12 +20,15 @@ impl GitHubService {
     }
 
     pub async fn request_github_auth(&self, body: &GitHubAuthRequest) -> GitHubTempTokenResult {
+        let mut headers = HeaderMap::new();
+        headers.insert("Accept", "application/json".parse().unwrap());
         self.server_connection
             .request_with_json_result(
                 Method::POST,
                 "login/device/code",
                 Query::<()>::None,
                 Body::Json(body),
+                Some(headers),
             )
             .await
     }

--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -16,6 +16,7 @@ mod async_worker;
 mod event;
 mod game;
 mod github;
+mod github_service;
 mod plugin;
 mod server_connection;
 mod server_service;

--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -4,6 +4,7 @@
 pub use async_worker::*;
 pub use event::*;
 pub use game::*;
+pub use github::*;
 pub use plugin::*;
 pub use server_connection::*;
 pub use server_service::*;

--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -14,6 +14,7 @@ pub use whist_info::*;
 mod async_worker;
 mod event;
 mod game;
+mod github;
 mod plugin;
 mod server_connection;
 mod server_service;

--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -5,6 +5,7 @@ pub use async_worker::*;
 pub use event::*;
 pub use game::*;
 pub use github::*;
+pub use github_service::*;
 pub use plugin::*;
 pub use server_connection::*;
 pub use server_service::*;

--- a/src/network/plugin.rs
+++ b/src/network/plugin.rs
@@ -13,6 +13,7 @@ impl Plugin for NetworkPlugin {
             .add_event::<GameListResult>()
             .add_event::<GameJoinResult>()
             .add_event::<GameCreateResult>()
+            .add_event::<GitHubTempTokenResult>()
             .add_event::<WebSocketCommand>()
             .add_startup_system(setup_worker)
             .add_system(send_network_events)

--- a/src/network/plugin.rs
+++ b/src/network/plugin.rs
@@ -95,13 +95,9 @@ async fn network_worker(mut worker: NetworkWorkerFlipped) {
                 };
             }
             NetworkCommand::GithubAuth(github_request) => {
-                let github_service = Some(GitHubService::new("https://github.com"));
+                let github_service = GitHubService::new("https://github.com");
                 worker.send(NetworkResponse::GithubAuth(
-                    github_service
-                        .as_ref()
-                        .unwrap()
-                        .request_github_auth(&github_request)
-                        .await,
+                    github_service.request_github_auth(&github_request).await,
                 ));
             }
             NetworkCommand::Login(login_form) => {

--- a/src/network/server_service.rs
+++ b/src/network/server_service.rs
@@ -76,6 +76,25 @@ impl ServerService {
         }
     }
 
+    pub async fn github_auth(&mut self, body: &SwapTokenRequest) -> Result<(), LoginError> {
+        let res: LoginResponse = self
+            .server_connection
+            .request_with_json_result(
+                Method::POST,
+                "oauth2/github/device",
+                Query::<()>::None,
+                Body::Json(body),
+                None,
+            )
+            .await?;
+        if BEARER_TOKEN_TYPE == res.token_type {
+            self.server_connection.token(res.access_token);
+            Ok(())
+        } else {
+            Err(LoginError::UnknownTokenType(res.token_type))
+        }
+    }
+
     pub async fn create_user(&self, body: &UserCreateRequest) -> Result<UserCreateResponse, Error> {
         self.server_connection
             .request_with_json_result(

--- a/src/network/server_service.rs
+++ b/src/network/server_service.rs
@@ -140,7 +140,10 @@ impl GitHubService {
         }
     }
 
-    pub async fn request_github_auth(&self, body: &GitHubAuthRequest) -> GitHubTempTokenResult {
+    pub async fn request_github_auth(
+        &self,
+        body: &GitHubAuthRequest,
+    ) -> Result<GitHubTempTokenResult, AuthError> {
         self.server_connection
             .request_with_json_result(
                 Method::POST,

--- a/src/network/server_service.rs
+++ b/src/network/server_service.rs
@@ -27,9 +27,15 @@ pub struct ServerService {
     server_connection: ServerConnection,
 }
 
+/// Service to provide call to github routes.
+pub struct GitHubService {
+    server_connection: ServerConnection,
+}
+
 pub type GameListResult = Result<GameListResponse, Error>;
 pub type GameJoinResult = Result<GameJoinResponse, Error>;
 pub type GameCreateResult = Result<GameCreateResponse, Error>;
+pub type GitHubTempTokenResult = Result<GitHubTempTokenResponse, Error>;
 
 impl ServerService {
     /// Constructor
@@ -117,6 +123,28 @@ impl ServerService {
             .request_with_json_result(
                 Method::POST,
                 "game/create",
+                Query::<()>::None,
+                Body::Json(body),
+            )
+            .await
+    }
+}
+
+impl GitHubService {
+    /// Constructor
+    /// # Arguments
+    /// * 'base_url' the url of the server
+    pub fn new(base_url: impl IntoUrl) -> Self {
+        Self {
+            server_connection: ServerConnection::new(base_url),
+        }
+    }
+
+    pub async fn request_github_auth(&self, body: &GitHubAuthRequest) -> GitHubTempTokenResult {
+        self.server_connection
+            .request_with_json_result(
+                Method::POST,
+                "login/device/code",
                 Query::<()>::None,
                 Body::Json(body),
             )

--- a/src/network/server_service.rs
+++ b/src/network/server_service.rs
@@ -30,7 +30,6 @@ pub struct ServerService {
 pub type GameListResult = Result<GameListResponse, Error>;
 pub type GameJoinResult = Result<GameJoinResponse, Error>;
 pub type GameCreateResult = Result<GameCreateResponse, Error>;
-pub type GitHubTempTokenResult = Result<GitHubTempTokenResponse, Error>;
 
 impl ServerService {
     /// Constructor

--- a/src/network/server_service.rs
+++ b/src/network/server_service.rs
@@ -27,11 +27,6 @@ pub struct ServerService {
     server_connection: ServerConnection,
 }
 
-/// Service to provide call to github routes.
-pub struct GitHubService {
-    server_connection: ServerConnection,
-}
-
 pub type GameListResult = Result<GameListResponse, Error>;
 pub type GameJoinResult = Result<GameJoinResponse, Error>;
 pub type GameCreateResult = Result<GameCreateResponse, Error>;
@@ -123,31 +118,6 @@ impl ServerService {
             .request_with_json_result(
                 Method::POST,
                 "game/create",
-                Query::<()>::None,
-                Body::Json(body),
-            )
-            .await
-    }
-}
-
-impl GitHubService {
-    /// Constructor
-    /// # Arguments
-    /// * 'base_url' the url of the server
-    pub fn new(base_url: impl IntoUrl) -> Self {
-        Self {
-            server_connection: ServerConnection::new(base_url),
-        }
-    }
-
-    pub async fn request_github_auth(
-        &self,
-        body: &GitHubAuthRequest,
-    ) -> Result<GitHubTempTokenResult, AuthError> {
-        self.server_connection
-            .request_with_json_result(
-                Method::POST,
-                "login/device/code",
                 Query::<()>::None,
                 Body::Json(body),
             )

--- a/src/network/user.rs
+++ b/src/network/user.rs
@@ -44,6 +44,19 @@ impl LoginResponse {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct SwapTokenRequest {
+    pub device_code: String,
+}
+
+impl SwapTokenRequest {
+    pub fn new(device_code: impl Into<String>) -> Self {
+        Self {
+            device_code: device_code.into(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct UserCreateRequest {
     pub username: String,
     pub password: String,

--- a/src/network/user.rs
+++ b/src/network/user.rs
@@ -1,6 +1,5 @@
 use reqwest::Error;
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
 use std::fmt;
 
 #[derive(Debug)]
@@ -60,9 +59,9 @@ impl SwapTokenRequest {
 
 impl fmt::Debug for SwapTokenRequest {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let mut output = HashMap::new();
-        output.insert("device_code", &self.device_code);
-        write!(f, "SwapTokenRequest {:?}", output)
+        f.debug_struct("SwapTokenRequest")
+            .field("device_code", &self.device_code)
+            .finish()
     }
 }
 

--- a/src/network/user.rs
+++ b/src/network/user.rs
@@ -1,5 +1,7 @@
 use reqwest::Error;
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::fmt;
 
 #[derive(Debug)]
 pub enum LoginError {
@@ -53,6 +55,14 @@ impl SwapTokenRequest {
         Self {
             device_code: device_code.into(),
         }
+    }
+}
+
+impl fmt::Debug for SwapTokenRequest {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let mut output = HashMap::new();
+        output.insert("device_code", &self.device_code);
+        write!(f, "SwapTokenRequest {:?}", output)
     }
 }
 

--- a/src/network/user.rs
+++ b/src/network/user.rs
@@ -45,7 +45,7 @@ impl LoginResponse {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct SwapTokenRequest {
     pub device_code: String,
 }


### PR DESCRIPTION
- [x] Hide `client_id` in logs
- [x] Hide `device_code` in logs
- [x] Github returns error fixed in #65 
```
2022-08-03T21:44:35.592654Z  INFO whist_browser::network::plugin: network event: GithubAuth(GitHubAuthRequest { client_id: "XXX" })
2022-08-03T21:44:35.592769Z  INFO whist_browser::network::plugin: receiving network command GithubAuth(GitHubAuthRequest { client_id: "XXX" })
2022-08-03T21:44:35.611719Z  INFO whist_browser::network::server_connection: http request: POST https://github.com/login/device/code query=None body=Json(GitHubAuthRequest { client_id: "XXX" }) auth=None
2022-08-03T21:44:35.799928Z  INFO whist_browser::network::server_connection: http response: Response { url: Url { scheme: "https", cannot_be_a_base: false, username: "", password: None, host: Some(Domain("github.com")), port: None, path: "/login/device/code", query: None, fragment: None }, status: 200, headers: {"server": "GitHub.com", "date": "Wed, 03 Aug 2022 21:44:35 GMT", "content-type": "application/x-www-form-urlencoded; charset=utf-8", "transfer-encoding": "chunked", "vary": "X-PJAX, X-PJAX-Container, Turbo-Visit, Turbo-Frame", "vary": "Accept-Encoding, Accept, X-Requested-With", "permissions-policy": "interest-cohort=()", "etag": "W/\"c67f6dd933ee1dd5dfc1545ed564db13\"", "cache-control": "max-age=0, private, must-revalidate", "strict-transport-security": "max-age=31536000; includeSubdomains; preload", "x-frame-options": "deny", "x-content-type-options": "nosniff", "x-xss-protection": "0", "referrer-policy": "origin-when-cross-origin, strict-origin-when-cross-origin", "expect-ct": "max-age=2592000, report-uri=\"https://api.github.com/_private/browser/errors\"", "content-security-policy": "default-src 'none'; base-uri 'self'; block-all-mixed-content; child-src github.com/assets-cdn/worker/ gist.github.com/assets-cdn/worker/; connect-src 'self' uploads.github.com objects-origin.githubusercontent.com www.githubstatus.com collector.github.com raw.githubusercontent.com api.github.com github-cloud.s3.amazonaws.com github-production-repository-file-5c1aeb.s3.amazonaws.com github-production-upload-manifest-file-7fdce7.s3.amazonaws.com github-production-user-asset-6210df.s3.amazonaws.com cdn.optimizely.com logx.optimizely.com/v1/events *.actions.githubusercontent.com wss://*.actions.githubusercontent.com online.visualstudio.com/api/v1/locations github-production-repository-image-32fea6.s3.amazonaws.com github-production-release-asset-2e65be.s3.amazonaws.com insights.github.com wss://alive.github.com; font-src github.githubassets.com; form-action 'self' github.com gist.github.com objects-origin.githubusercontent.com; frame-ancestors 'none'; frame-src render.githubusercontent.com viewscreen.githubusercontent.com notebooks.githubusercontent.com; img-src 'self' data: github.githubassets.com identicons.github.com github-cloud.s3.amazonaws.com secured-user-images.githubusercontent.com/ github-production-user-asset-6210df.s3.amazonaws.com customer-stories-feed.github.com spotlights-feed.github.com *.githubusercontent.com; manifest-src 'self'; media-src github.com user-images.githubusercontent.com/ secured-user-images.githubusercontent.com/; script-src github.githubassets.com; style-src 'unsafe-inline' github.githubassets.com; worker-src github.com/assets-cdn/worker/ gist.github.com/assets-cdn/worker/", "x-github-request-id": "C4E2:6FC0:C96E80:D5D6DA:62EAEC43"} }
2022-08-03T21:44:35.838481Z  INFO whist_browser::network::plugin: worker response: GithubAuth(Err(reqwest::Error { kind: Decode, source: Error("expected value", line: 1, column: 1) }))
```
- [x] Switch to game room ui after successful auth